### PR TITLE
editorconfig: Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+# http://EditorConfig.org
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+
+[*.{c,h}]
+indent_size = 8
+indent_style = space


### PR DESCRIPTION
We have mixed spaces and tabs.  From now on, we only want spaces for
source code indentation.

Signed-off-by: Yasushi SHOJI <yashi@spacecubics.com>