### PR TITLE
all: Convert all tabs to spaces

### DIFF
--- a/src/cmd_parser.c
+++ b/src/cmd_parser.c
@@ -45,54 +45,54 @@ static char conv_asc2hex (char data) {
                 return 0x00;
 }
 
-#define bswap32(x) ((uint32_t) ( (((x) & 0x000000ff) << 24) |	\
-				 (((x) & 0x0000ff00) <<  8) |	\
-				 (((x) & 0x00ff0000) >>  8) |	\
-				 (((x) & 0xff000000) >> 24)) )
+#define bswap32(x) ((uint32_t) ( (((x) & 0x000000ff) << 24) |   \
+                                 (((x) & 0x0000ff00) <<  8) |   \
+                                 (((x) & 0x00ff0000) >>  8) |   \
+                                 (((x) & 0xff000000) >> 24)) )
 
 static void cmd_chkreg(struct fpga_management_data *fmd) {
-	uint8_t buf[BUF_LEN];
+        uint8_t buf[BUF_LEN];
 
-	usart_send_msg("TRISA");
-	buf[0] = TRISA;
-	conv_message(buf, 1);
-	usart_send_msg("PORTA");
-	buf[0] = PORTA;
-	conv_message(buf, 1);
+        usart_send_msg("TRISA");
+        buf[0] = TRISA;
+        conv_message(buf, 1);
+        usart_send_msg("PORTA");
+        buf[0] = PORTA;
+        conv_message(buf, 1);
 
-	usart_send_msg("TRISB");
-	buf[0] = TRISB;
-	conv_message(buf, 1);
-	usart_send_msg("PORTB");
-	buf[0] = PORTB;
-	conv_message(buf, 1);
+        usart_send_msg("TRISB");
+        buf[0] = TRISB;
+        conv_message(buf, 1);
+        usart_send_msg("PORTB");
+        buf[0] = PORTB;
+        conv_message(buf, 1);
 
-	usart_send_msg("TRISC");
-	buf[0] = TRISC;
-	conv_message(buf, 1);
-	usart_send_msg("PORTC");
-	buf[0] = PORTC;
-	conv_message(buf, 1);
+        usart_send_msg("TRISC");
+        buf[0] = TRISC;
+        conv_message(buf, 1);
+        usart_send_msg("PORTC");
+        buf[0] = PORTC;
+        conv_message(buf, 1);
 
-	usart_send_msg("TRISD");
-	buf[0] = TRISD;
-	conv_message(buf, 1);
-	usart_send_msg("PORTD");
-	buf[0] = PORTD;
-	conv_message(buf, 1);
+        usart_send_msg("TRISD");
+        buf[0] = TRISD;
+        conv_message(buf, 1);
+        usart_send_msg("PORTD");
+        buf[0] = PORTD;
+        conv_message(buf, 1);
 
-	usart_send_msg("TRISE");
-	buf[0] = TRISE;
-	conv_message(buf, 1);
-	usart_send_msg("PORTE");
-	buf[0] = PORTE;
-	conv_message(buf, 1);
+        usart_send_msg("TRISE");
+        buf[0] = TRISE;
+        conv_message(buf, 1);
+        usart_send_msg("PORTE");
+        buf[0] = PORTE;
+        conv_message(buf, 1);
 
-	usart_send_msg("FPGA State");
-	buf[0] = fmd->state;
-	conv_message(buf, 1);
-	buf[0] = (char)(fmd->count);
-	conv_message(buf, 1);
+        usart_send_msg("FPGA State");
+        buf[0] = fmd->state;
+        conv_message(buf, 1);
+        buf[0] = (char)(fmd->count);
+        conv_message(buf, 1);
 }
 
 void cmd_parser (struct fpga_management_data *fmd, char *msg) {
@@ -118,11 +118,11 @@ void cmd_parser (struct fpga_management_data *fmd, char *msg) {
                         fmd->config_ok = 0;
 
         // Timer
-	} else if (!strncmp(msg, "gtimer", 6)) {
-		uint32_t ticks = timer_get_ticks();
-		ticks = bswap32(ticks);
-		usart_send_msg("Global Timer");
-		conv_message((uint8_t *)&ticks, sizeof(ticks));
+        } else if (!strncmp(msg, "gtimer", 6)) {
+                uint32_t ticks = timer_get_ticks();
+                ticks = bswap32(ticks);
+                usart_send_msg("Global Timer");
+                conv_message((uint8_t *)&ticks, sizeof(ticks));
 
         // Configuration Memory Select
         } else if (!strncmp(msg,"ms",2)) {
@@ -201,9 +201,9 @@ void cmd_parser (struct fpga_management_data *fmd, char *msg) {
                         usart_send_msg("Sensor number error");
 
                 if (temp.addr != 0) {
-			int8_t ret;
+                        int8_t ret;
 
-			ret = tmp175_data_read(&temp, fmd->state);
+                        ret = tmp175_data_read(&temp, fmd->state);
                         if (ret < 0 && temp.error == TMP175_ERROR_I2C_NAK)
                                 usart_send_msg("i2c bus error");
                         conv_message(temp.data,2);
@@ -225,10 +225,10 @@ void cmd_parser (struct fpga_management_data *fmd, char *msg) {
                         usart_send_msg("Sensor number error");
                 voltage.channel = buf[1];
                 if (buf[2] == 0x00 || buf[2] == 0x01) {
-			int8_t ret;
+                        int8_t ret;
 
                         type = buf[2] == 0x0 ? INA3221_VOLTAGE_SHUNT : INA3221_VOLTAGE_BUS;
-			ret = ina3221_data_read(&voltage, fmd->state, type);
+                        ret = ina3221_data_read(&voltage, fmd->state, type);
                         if (ret < 0 && voltage.error == INA3221_ERROR_I2C_NAK)
                                 usart_send_msg("i2c bus error");
                         if (type == INA3221_VOLTAGE_BUS)
@@ -285,7 +285,7 @@ void cmd_parser (struct fpga_management_data *fmd, char *msg) {
 
         // Register Check
         } else if (!strcmp(msg,"chkreg")) {
-		cmd_chkreg(fmd);
+                cmd_chkreg(fmd);
         } else
                 usart_send_msg("cmd error");
         usart_receive_msg_clear();

--- a/src/fpga.c
+++ b/src/fpga.c
@@ -63,7 +63,7 @@ static void f_fpga_active (struct fpga_management_data *fmd) {
 }
 
 STATEFUNC fpgafunc[] = {
-	f_power_off,
-	f_fpga_ready,
-	f_fpga_config,
-	f_fpga_active };
+        f_power_off,
+        f_fpga_ready,
+        f_fpga_config,
+        f_fpga_active };

--- a/src/fpga.h
+++ b/src/fpga.h
@@ -12,11 +12,11 @@
 #include <stdbool.h>
 
 enum FpgaState{
-	FPGA_STATE_POWER_OFF,
-	FPGA_STATE_READY,
-	FPGA_STATE_CONFIG,
-	FPGA_STATE_ACTIVE,
-	FPGA_STATE_LAST,
+        FPGA_STATE_POWER_OFF,
+        FPGA_STATE_READY,
+        FPGA_STATE_CONFIG,
+        FPGA_STATE_ACTIVE,
+        FPGA_STATE_LAST,
 };
 
 struct fpga_management_data {

--- a/src/ina3221.c
+++ b/src/ina3221.c
@@ -19,34 +19,34 @@
 
 static uint8_t to_reg (uint8_t channel, enum Ina3221VoltageType type) {
 
-	/*
-	 * reg 0: configuration
-	 * reg 1: channel 1 shunt
-	 * reg 2: channel 1 bus
-	 * reg 3: channel 2 shunt
-	 * reg 4: channel 2 bus
-	 * reg 5: channel 3 shunt
-	 * reg 6: channel 3 bus
-	 */
-	return ((channel - 1) * 2) + REG_VOLTAGE_BASE + type;
+        /*
+         * reg 0: configuration
+         * reg 1: channel 1 shunt
+         * reg 2: channel 1 bus
+         * reg 3: channel 2 shunt
+         * reg 4: channel 2 bus
+         * reg 5: channel 3 shunt
+         * reg 6: channel 3 bus
+         */
+        return ((channel - 1) * 2) + REG_VOLTAGE_BASE + type;
 }
 
 int8_t ina3221_data_read (struct ina3221_data *id, enum FpgaState fpga_state, enum Ina3221VoltageType type) {
         uint8_t addr = (uint8_t)(id->addr << 1);
         uint8_t reg_addr;
         uint8_t nak = 0;
-	int8_t ret = -1;
+        int8_t ret = -1;
 
-	if (!(type == INA3221_VOLTAGE_SHUNT || type == INA3221_VOLTAGE_BUS)) {
-		id->error = INA3221_ERROR_INVALID_VOLTAGE_TYPE;
-		return ret;
-	}
-	if (!fpga_is_i2c_accessible(fpga_state)) {
-		id->error = INA3221_ERROR_I2C_UNACCESSIBLE;
-		return ret;
-	}
+        if (!(type == INA3221_VOLTAGE_SHUNT || type == INA3221_VOLTAGE_BUS)) {
+                id->error = INA3221_ERROR_INVALID_VOLTAGE_TYPE;
+                return ret;
+        }
+        if (!fpga_is_i2c_accessible(fpga_state)) {
+                id->error = INA3221_ERROR_I2C_UNACCESSIBLE;
+                return ret;
+        }
 
-	reg_addr = to_reg(id->channel, type);
+        reg_addr = to_reg(id->channel, type);
         i2c_get(id->master);
 
         interrupt_disable();
@@ -69,10 +69,10 @@ int8_t ina3221_data_read (struct ina3221_data *id, enum FpgaState fpga_state, en
         i2c_send_stop(id->master);
         interrupt_enable();
 
-	if (nak != 0) {
-		id->error = INA3221_ERROR_I2C_NAK;
-		return ret;
-	}
+        if (nak != 0) {
+                id->error = INA3221_ERROR_I2C_NAK;
+                return ret;
+        }
 
         return 0;
 }

--- a/src/ina3221.h
+++ b/src/ina3221.h
@@ -14,13 +14,13 @@
 #include "fpga.h"
 
 enum Ina3221VoltageType {
-	INA3221_VOLTAGE_SHUNT,
-	INA3221_VOLTAGE_BUS,
+        INA3221_VOLTAGE_SHUNT,
+        INA3221_VOLTAGE_BUS,
 };
 
-#define INA3221_ERROR_I2C_UNACCESSIBLE		(1)
-#define INA3221_ERROR_I2C_NAK			(2)
-#define INA3221_ERROR_INVALID_VOLTAGE_TYPE	(3)
+#define INA3221_ERROR_I2C_UNACCESSIBLE          (1)
+#define INA3221_ERROR_I2C_NAK                   (2)
+#define INA3221_ERROR_INVALID_VOLTAGE_TYPE      (3)
 
 struct ina3221_data {
         int  master;

--- a/src/interrupt.c
+++ b/src/interrupt.c
@@ -12,11 +12,11 @@
 #include <pic.h>
 
 void interrupt_disable () {
-	INTCONbits.PEIE = 0;
-	INTCONbits.GIE = 0;
+        INTCONbits.PEIE = 0;
+        INTCONbits.GIE = 0;
 }
 
 void interrupt_enable () {
-	INTCONbits.PEIE = 1;
-	INTCONbits.GIE = 1;
+        INTCONbits.PEIE = 1;
+        INTCONbits.GIE = 1;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -49,7 +49,7 @@ struct board_status {
 
 static void get_voltage_monitor (struct ina3221_data *id, enum FpgaState fpga_state, enum Ina3221VoltageType type) {
         int retry = 3;
-	int8_t ret;
+        int8_t ret;
 
         while (retry) {
                 ret = ina3221_data_read(id, fpga_state, type);
@@ -62,7 +62,7 @@ static void get_voltage_monitor (struct ina3221_data *id, enum FpgaState fpga_st
 
 static void get_tmp (struct tmp175_data *td, enum FpgaState fpga_state) {
         int retry = 3;
-	int8_t ret;
+        int8_t ret;
 
         while (retry) {
                 ret = tmp175_data_read(td, fpga_state);
@@ -197,10 +197,10 @@ void main (void) {
                 fpgafunc[tst.fmd.state](&tst.fmd);
 
                 if (usart_is_received_msg_active()) {
-			char msg[MSG_LEN];
-			usart_copy_received_msg(msg);
+                        char msg[MSG_LEN];
+                        usart_copy_received_msg(msg);
                         cmd_parser(&tst.fmd, msg);
-		}
+                }
         }
         return;
 }

--- a/src/timer.c
+++ b/src/timer.c
@@ -9,7 +9,7 @@
 
 #include "timer.h"
 
-#include <pic.h>
+#include <pic16f877.h>
 #include <stdint.h>
 
 #include "interrupt.h"
@@ -22,11 +22,11 @@ static uint32_t current_ticks;
 
 uint32_t timer_get_ticks(void)
 {
-	interrupt_disable();
-	uint32_t ret = current_ticks;
-	interrupt_enable();
+        interrupt_disable();
+        uint32_t ret = current_ticks;
+        interrupt_enable();
 
-	return ret;
+        return ret;
 }
 
 /*
@@ -37,7 +37,7 @@ void timer2_init (void) {
         T2CONbits.T2CKPS = 0b10;
         PR2 = 0xFA;
 
-	current_ticks = 0;
+        current_ticks = 0;
 }
 
 void timer2_ctrl (uint8_t control) {
@@ -46,14 +46,14 @@ void timer2_ctrl (uint8_t control) {
 }
 
 void timer2_isr (void) {
-	static uint8_t count = 0;
+        static uint8_t count = 0;
 
-	PIR1bits.TMR2IF = 0;
+        PIR1bits.TMR2IF = 0;
 
-	count++;
-	count %= SEC_IN_MSEC(1) / TIMER_INTERVAL;
+        count++;
+        count %= SEC_IN_MSEC(1) / TIMER_INTERVAL;
 
-	if (count == 0) {
-		current_ticks++;
-	}
+        if (count == 0) {
+                current_ticks++;
+        }
 }

--- a/src/tmp175.c
+++ b/src/tmp175.c
@@ -18,12 +18,12 @@
 int8_t tmp175_data_read (struct tmp175_data *td, enum FpgaState fpga_state) {
         uint8_t addr = (uint8_t)(td->addr << 1);
         uint8_t nak = 0;
-	int8_t ret = -1;
+        int8_t ret = -1;
 
-	if (fpga_is_i2c_accessible(fpga_state)) {
-		td->error = TMP175_ERROR_I2C_UNACCESSIBLE;
-		return ret;
-	}
+        if (fpga_is_i2c_accessible(fpga_state)) {
+                td->error = TMP175_ERROR_I2C_UNACCESSIBLE;
+                return ret;
+        }
 
         i2c_get(td->master);
 
@@ -38,10 +38,10 @@ int8_t tmp175_data_read (struct tmp175_data *td, enum FpgaState fpga_state) {
         i2c_send_stop(td->master);
         interrupt_enable();
 
-	if (nak != 0) {
-		td->error = TMP175_ERROR_I2C_NAK;
-		return ret;
-	}
+        if (nak != 0) {
+                td->error = TMP175_ERROR_I2C_NAK;
+                return ret;
+        }
 
         return 0;
 }

--- a/src/tmp175.h
+++ b/src/tmp175.h
@@ -17,8 +17,8 @@
 #define REG_TLOW   0x02
 #define REG_THIGH  0x03
 
-#define TMP175_ERROR_I2C_UNACCESSIBLE		(1)
-#define TMP175_ERROR_I2C_NAK			(2)
+#define TMP175_ERROR_I2C_UNACCESSIBLE           (1)
+#define TMP175_ERROR_I2C_NAK                    (2)
 
 struct tmp175_data {
         uint8_t master;

--- a/src/usart.c
+++ b/src/usart.c
@@ -50,7 +50,7 @@ void usart_send_msg (char *msg) {
         int i;
         tx_msg.msg = msg;
         tx_msg.active = 1;
-	char newline[2] = {0x0d, 0x0a};
+        char newline[2] = {0x0d, 0x0a};
 
         // Transfer start
         while (tx_msg.active) {
@@ -104,20 +104,20 @@ void usart_receive_msg_isr (void) {
 }
 
 void usart_receive_msg_clear (void) {
-	interrupt_disable();
+        interrupt_disable();
         memset(rx_msg.msg, 0, MSG_LEN);
         rx_msg.active = 0;
         rx_msg.err = 0;
         rx_msg.addr = 0;
-	interrupt_enable();
+        interrupt_enable();
 }
 
 void usart_copy_received_msg(char *msg) {
-	interrupt_disable();
-	memcpy(msg, rx_msg.msg, MSG_LEN);
-	interrupt_enable();
+        interrupt_disable();
+        memcpy(msg, rx_msg.msg, MSG_LEN);
+        interrupt_enable();
 }
 
 bool usart_is_received_msg_active (void) {
-	return rx_msg.active;
+        return rx_msg.active;
 }


### PR DESCRIPTION
Our coding standard is spaces instead of tabs for indentations.
Convert all tabs to spaces.

Signed-off-by: Yasushi SHOJI <yashi@spacecubics.com>