### PR TITLE
timer: Replace pic16f877.h with pic.h

### DIFF
--- a/src/timer.c
+++ b/src/timer.c
@@ -9,7 +9,7 @@
 
 #include "timer.h"
 
-#include <pic16f877.h>
+#include <pic.h>
 #include <stdint.h>
 
 #include "interrupt.h"


### PR DESCRIPTION
The commit c734acd3a8 converted pic16f877.h with pic.h by accident.  I
was testing a few bits and pices with timer code at the time and left
them in the commit.  Do not include a device specific header file but
always use pic.h.

Signed-off-by: Yasushi SHOJI <yashi@spacecubics.com>