### PR TITLE
Updated TRCH and FPGA initialization

### DIFF
--- a/src/fpga.c
+++ b/src/fpga.c
@@ -16,6 +16,8 @@
 void fpga_init (struct fpga_management_data *fmd) {
         fmd->state = FPGA_STATE_POWER_OFF;
         fmd->config_ok = 0;
+        fmd->config_mem = 0;
+        fmd->boot_mode = 1;
         fmd->count = 0;
         fmd->time = 0;
 }
@@ -35,6 +37,9 @@ static void f_power_off (struct fpga_management_data *fmd) {
 
 static void f_fpga_ready (struct fpga_management_data *fmd) {
         if (fmd->config_ok) {
+                TRCH_CFG_MEM_SEL = fmd->config_mem;
+                FPGA_BOOT0 = 0b01 & fmd->boot_mode;
+                FPGA_BOOT1 = (0b01 & fmd->boot_mode) >> 1;
                 if (fmd->count == 0)
                         FPGA_INIT_B_DIR = 1;
                 else

--- a/src/fpga.h
+++ b/src/fpga.h
@@ -1,3 +1,4 @@
+
 /*
  * Space Cubics OBC TRCH Software
  *  Definitions for FPGA Control Utility
@@ -22,6 +23,8 @@ enum FpgaState{
 struct fpga_management_data {
         enum FpgaState state;
         unsigned config_ok: 1;
+        unsigned config_mem: 1;
+        unsigned boot_mode: 2;
         int count;
         int time;
 };

--- a/src/main.c
+++ b/src/main.c
@@ -106,16 +106,16 @@ static void __interrupt() isr(void) {
 
 static void trch_init (void) {
         ADCON1 = 0x07;
-        TRISA = TRISA_INIT;
         PORTA = PORTA_INIT;
-        TRISB = TRISB_INIT;
+        TRISA = TRISA_INIT;
         PORTB = PORTB_INIT;
-        TRISC = TRISC_INIT;
+        TRISB = TRISB_INIT;
         PORTC = PORTC_INIT;
-        TRISD = TRISD_INIT;
+        TRISC = TRISC_INIT;
         PORTD = PORTD_INIT;
-        TRISE = TRISE_INIT;
+        TRISD = TRISD_INIT;
         PORTE = PORTE_INIT;
+        TRISE = TRISE_INIT;
 }
 
 void main (void) {

--- a/src/trch.h
+++ b/src/trch.h
@@ -30,6 +30,8 @@
 
 #define TRISA_FPGA_READY   0x00
 #define TRCH_CFG_MEM_SEL   PORTAbits.RA0
+#define FPGA_BOOT0         PORTAbits.RA1
+#define FPGA_BOOT1         PORTAbits.RA2
 #define FPGA_PROGRAM_B     PORTAbits.RA3
 #define FPGA_PROGRAM_B_DIR TRISAbits.TRISA3
 #define FPGA_INIT_B        PORTAbits.RA4


### PR DESCRIPTION
Updated the initialization sequence when TRCH and FPGA are configured.

**TRCH**
- Change the control order of ports at initialization

**FPGA**
- Added memory bank settings (to switch banks in the future)
- Added operation mode setting when FPGA boots