### PR TITLE
Wait for VDD 3.3V

### DIFF
--- a/src/fpga.c
+++ b/src/fpga.c
@@ -50,7 +50,7 @@ static bool fpga_wdt(struct fpga_management_data *fmd, bool wdt_value, uint32_t 
                         fmd->wdt_last_tick = tick;
                 }
 
-                if (fmd->wdt_last_tick + CONFIG_FPGA_WATCHDOG_TIMEOUT < tick)
+                if (fmd->wdt_last_tick + MSEC_TO_TICKS(CONFIG_FPGA_WATCHDOG_TIMEOUT * 1000) < tick)
                         ret = false;
         }
         return ret;

--- a/src/fpga.h
+++ b/src/fpga.h
@@ -17,7 +17,9 @@
 #define FPGA_BOOT_96MHZ 2
 
 enum FpgaState{
+        FPGA_STATE_POWER_DOWN,
         FPGA_STATE_POWER_OFF,
+        FPGA_STATE_POWER_UP,
         FPGA_STATE_READY,
         FPGA_STATE_CONFIG,
         FPGA_STATE_ACTIVE,

--- a/src/timer.c
+++ b/src/timer.c
@@ -51,7 +51,7 @@ void timer2_isr (void) {
         PIR1bits.TMR2IF = 0;
 
         count++;
-        count %= MSEC_PER_SEC / TIMER_INTERVAL;
+        count %= (MSEC_PER_SEC / HZ) / TIMER_INTERVAL;
 
         if (count == 0) {
                 current_ticks++;

--- a/src/timer.c
+++ b/src/timer.c
@@ -14,7 +14,6 @@
 
 #include "interrupt.h"
 
-#define MSEC_PER_SEC (1000)
 #define MSEC(x) (x)
 #define TIMER_INTERVAL (MSEC(4))
 

--- a/src/timer.c
+++ b/src/timer.c
@@ -14,7 +14,7 @@
 
 #include "interrupt.h"
 
-#define SEC_IN_MSEC(x) (1000 * (x))
+#define MSEC_PER_SEC (1000)
 #define MSEC(x) (x)
 #define TIMER_INTERVAL (MSEC(4))
 
@@ -51,7 +51,7 @@ void timer2_isr (void) {
         PIR1bits.TMR2IF = 0;
 
         count++;
-        count %= SEC_IN_MSEC(1) / TIMER_INTERVAL;
+        count %= MSEC_PER_SEC / TIMER_INTERVAL;
 
         if (count == 0) {
                 current_ticks++;

--- a/src/timer.h
+++ b/src/timer.h
@@ -12,6 +12,8 @@
 #include <stdint.h>
 
 #define HZ (1)
+#define MSEC_PER_SEC (1000)
+#define MSEC_TO_TICKS(ms) (((ms) + ((MSEC_PER_SEC / HZ) - 1)) / (MSEC_PER_SEC / HZ))
 
 extern void timer2_init (void);
 extern void timer2_ctrl (uint8_t control);

--- a/src/timer.h
+++ b/src/timer.h
@@ -11,6 +11,8 @@
 
 #include <stdint.h>
 
+#define HZ (1)
+
 extern void timer2_init (void);
 extern void timer2_ctrl (uint8_t control);
 extern void timer2_isr (void);


### PR DESCRIPTION
We need to wait for Vdd 3.3 V to stabilize.  In order to do so, I've introduced a maco `MSEC_TO_TICKS`.  This allows us to specify microsecond instead of a number of ticks.

Please note that this branch depends on #18.

Please review.