### PR TITLE
spi: Set TRISC4 IN

### DIFF
--- a/src/spi.c
+++ b/src/spi.c
@@ -16,6 +16,7 @@
 /*
  * SSPSTAT.SMP      : Sample bit        : 0b0
  * SSPSTAT.CKE      : Clock Edge        : 0b1
+ *
  * SSPCON.WCOL      : Write collision   : 0b0
  * SSPCON.SSPOV     : SSP Overflow      : 0b1
  * SSPCON.SSPEN     : Serial Port Enable: 0b1
@@ -25,8 +26,10 @@
 void spi_init (void) {
         SPICAN_CS_B_DIR = 0;
         SPICAN_CS_B = 1;
-        SPICAN_MOSI_DIR = 0;
         SPICAN_SCK_DIR = 0;
+        SPICAN_MISO_DIR = 1;
+        SPICAN_MOSI_DIR = 0;
+
         SSPSTAT = 0x40;
         SSPCON = 0x60;
 }

--- a/src/trch.h
+++ b/src/trch.h
@@ -82,6 +82,7 @@
 #define SPICAN_CS_B        PORTCbits.RC1
 #define FPGAPROG_MODE_B    PORTCbits.RC2
 #define SPICAN_SCK_DIR     TRISCbits.TRISC3
+#define SPICAN_MISO_DIR    TRISCbits.TRISC4
 #define SPICAN_MOSI_DIR    TRISCbits.TRISC5
 
 /*


### PR DESCRIPTION
TRISC4, which is a direction register for PORTC RC4, must be set IN, in order to use it as SDI.

To quote DS31016A 1997:

> To enable the serial port, SSP enable bit, SSPEN (SSPCON<5>), must
> be set. To reset or reconfigure SPI mode, clear the SSPEN bit which
> re-initializes the SSPCON register, and then set the SSPEN bit. This
> configures the SDI, SDO, SCK, and SS pins as serial port pins. For
> the pins to behave as the serial port function, they must have their
> data direction bits (in the TRIS register) appropriately
> programmed. That is:
>
>  - SDI must have the TRIS bit set
>  - SDO must have the TRIS bit cleared
>  - SCK (Master mode) must have the TRIS bit cleared
>  - SCK (Slave mode) must have the TRIS bit set
>  - SS must have the TRIS bit set
>
> Any serial port function that is not desired may be overridden by
> programming the corresponding data direction (TRIS) register to the
> opposite value. An example would be in master mode where you are only
> sending data (to a display driver), then both SDI and SS could be used
> as general purpose outputs by clearing their corresponding TRIS
> register bits.

DS30292D 2013 still has a wrong statement:

> SDI is automatically controlled by the SPI module

There is an interesting topic on Michrochip forumn: https://www.microchip.com/forums/m42815.aspx

Signed-off-by: Yasushi SHOJI <yashi@spacecubics.com>