### PR TITLE
Remove ifdef on fpga_management_data

### DIFF
--- a/src/fpga.c
+++ b/src/fpga.c
@@ -17,10 +17,8 @@
 
 struct fpga_management_data {
         enum FpgaState state;
-#ifdef CONFIG_ENABLE_WDT_RESET
         bool wdt_value;
         uint32_t wdt_last_tick;
-#endif
 };
 
 static struct fpga_management_data the_fmd;


### PR DESCRIPTION
Having #ifdef to remove members from a struct causes build error because the compiler assume that the member is still in the struct due to IS_ENABLE() macro.

Remove #ifdef for a workaround.  This adds a few unused bytes to constraint environment.  We'll fix this issue after the v1.0 release.

Signed-off-by: Yasushi SHOJI <yashi@spacecubics.com>