### PR TITLE
trch.h: Fix initial port setting

### DIFF
--- a/src/trch.h
+++ b/src/trch.h
@@ -122,7 +122,7 @@
 
 #define PORTC_INIT (                            \
         LOW(TRCH_CAN_SLEEP_EN_BIT) |            \
-        LOW(SPICAN_CS_B_BIT) |                  \
+        HIGH(SPICAN_CS_B_BIT) |                 \
         LOW(FPGAPROG_MODE_B_BIT) |              \
         LOW(SPICAN_SCK_BIT) |                   \
         LOW(SPICAN_MISO_BIT) |                  \

--- a/src/trch.h
+++ b/src/trch.h
@@ -193,7 +193,7 @@
 #define FPGA_INIT_B_IN_BIT    (_PORTE_RE2_POSITION)
 
 #define TRISE_INIT (                            \
-        IN(WDOG_OUT_BIT) |                      \
+        OUT(WDOG_OUT_BIT) |                     \
         IN(FPGA_PROGRAM_B_IN_BIT) |             \
         IN(FPGA_INIT_B_IN_BIT) )
 


### PR DESCRIPTION
This PR has two commits to fix two initial port settings.

The first one is `SPICAN_CS_B`.  Which was set to LOW.  But because we have a pull-up registor and `spi_init()` sets it back to HIGH, it's not a big problem.  But the initialization makes it dip for a bit of time.

The second one is for `WDOG_OUT`.  This signal is not use at the time.  It doesn't have any pull-ups or downs.  But it was left as INPUT.  This commit fix it by driving LOW.