### PR TITLE
ioboard: Add IO boards build support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *~
 *.p1
 *.d
+*.a
 log.*
 MPLABXLog.xml
 GPATH

--- a/src/ioboard.c
+++ b/src/ioboard.c
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2023 Space Cubics, LLC.
+ */
+
+/* A weak version of the function. Each IO board should define its own
+ * function.  Note that XC8 for PIC16LF877 with C90 library doesn't
+ * have weak attribute.  This will be linked at very last to full
+ * fill if not defined. */
+int ioboard_init(void) {
+        return 0;
+};

--- a/src/ioboard.h
+++ b/src/ioboard.h
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2023 Space Cubics, LLC.
+ */
+
+#pragma once
+
+int ioboard_init(void);

--- a/src/main.c
+++ b/src/main.c
@@ -19,6 +19,7 @@
 #include "usart.h"
 #include "timer.h"
 #include "interrupt.h"
+#include "ioboard.h"
 #include "version.h"
 
 // PIC16LF877A Configuration Bit Settings
@@ -66,6 +67,7 @@ void main (void)
         fpga_program_maybe();
         fpga_state = fpga_init();
 
+        ioboard_init();
         spi_init();
         usart_init();
         timer2_init();


### PR DESCRIPTION
Each project should have its own IO boards.  src/ioboard is the directory for them.  If the directory has a ioboard.mk, included it. The make file should define IOBOARD_SRCS with its source files. The files will be appended to SRCS and built.

Because the source files are not in src/ but under src/ioboard/, it can't access the header files in src/.  Add "-I src" to the compile command.

Because the current XC8 with C90 library doesn't support weak attribute, this commit adds a empty ioboard_init() as a library.  The library, libioboard.a, must be linked very last.