### PR TITLE
usart: Do not putch received data

### DIFF
--- a/src/usart.c
+++ b/src/usart.c
@@ -79,7 +79,6 @@ void usart_receive_msg_isr (void) {
                         buf = RCREG;
         } else {
                 buf = RCREG;
-                putch(buf);
                 if (buf == RX_MSG_DELIMITER)
                         rx_msg.active = 1;
                 else {


### PR DESCRIPTION
This is a leftover of a debug print from the command parser we used to have, whcih is removed by a06f49c0703aa.