### PR TITLE
Makefile: Specify device family pack for 16LF877

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,6 +13,9 @@ jobs:
       matrix:
         xc8-version:
           - 'v2.46'
+          - 'v2.50'
+          - 'v3.00'
+          - 'v3.10'
         dfp-version:
           - '1.7.162'
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,6 +30,13 @@ jobs:
           path: ${{ env.XC8_INSTALL_DIR }}
           key: xc8-${{ matrix.xc8-version }}-full-install-linux-x64-installer.run
 
+      - name: Cache DFP
+        uses: actions/cache@v5
+        id: cache-dfp
+        with:
+          path: ${{ env.DFP_INSTALL_DIR }}
+          key: dfp-${{ matrix.dfp-version }}
+
       - name: Download XC8
         if: steps.cache-xc8.outputs.cache-hit != 'true'
         run: |
@@ -42,6 +49,7 @@ jobs:
           fakeroot ./*.run --mode unattended --netservername localhost --LicenseType FreeMode --prefix $GITHUB_WORKSPACE/$XC8_INSTALL_DIR
 
       - name: Download & Install Device Family Packs
+        if: steps.cache-dfp.outputs.cache-hit != 'true'
         run: |
           wget https://packs.download.microchip.com/Microchip.PIC16Fxxx_DFP.${{ matrix.dfp-version }}.atpack
           mkdir -p $DFP_INSTALL_DIR/${{ matrix.dfp-version }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,6 +3,7 @@ on: [push, pull_request]
 env:
   XC8_URL: https://ww1.microchip.com/downloads/aemDocuments/documents/DEV/ProductDocuments/SoftwareTools
   XC8_INSTALL_DIR: microchip/xc8
+  DFP_INSTALL_DIR: mchp_packs/Microchip/PIC16Fxxx_DFP
 
 jobs:
   build:
@@ -12,6 +13,8 @@ jobs:
       matrix:
         xc8-version:
           - 'v2.46'
+        dfp-version:
+          - '1.7.162'
 
     steps:
       - name: Checkout
@@ -35,7 +38,13 @@ jobs:
         run: |
           fakeroot ./*.run --mode unattended --netservername localhost --LicenseType FreeMode --prefix $GITHUB_WORKSPACE/$XC8_INSTALL_DIR
 
+      - name: Download & Install Device Family Packs
+        run: |
+          wget https://packs.download.microchip.com/Microchip.PIC16Fxxx_DFP.${{ matrix.dfp-version }}.atpack
+          mkdir -p $DFP_INSTALL_DIR/${{ matrix.dfp-version }}
+          unzip Microchip.PIC16Fxxx_DFP.${{ matrix.dfp-version }}.atpack -d $DFP_INSTALL_DIR/${{ matrix.dfp-version }}
+
       - name: Build
         run: |
           export PATH=$GITHUB_WORKSPACE/$XC8_INSTALL_DIR/bin:$PATH
-          make
+          make TRCH_DFP=$DFP_INSTALL_DIR/${{ matrix.dfp-version }}/xc8

--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,10 @@ CONFIGS += -DCONFIG_FPGA_WATCHDOG_TIMEOUT=30
 MODULE := trch-firmware
 DEVICE := 16LF877
 TRCH_PICKIT ?= PPK4
+TRCH_DFP ?= $(HOME)/.mchp_packs/Microchip/PIC16Fxxx_DFP/1.7.162/xc8
 
 # Command variables
-CC     := xc8-cc -mcpu=$(DEVICE)
+CC     := xc8-cc -mcpu=$(DEVICE) -mdfp=$(TRCH_DFP)
 AR     := xc8-ar r
 IPECMD := ipecmd.sh
 RM     := rm -rf

--- a/README.org
+++ b/README.org
@@ -4,6 +4,13 @@
 
 * How to build and program
 ** Prerequisite
+
+   Since XC8 v3.10, you need to have a Device Family Pack for
+   PIC16LF877. Go to [[https://packs.download.microchip.com/][Microchip Packs Repository]], download, and install
+   it.  If you have X IDE installed, you might already have it.
+
+   Please read MPLAB XC8 C Compiler User's Guide for more details.
+
    #+begin_example
      $ xc8-cc --version
      Microchip MPLAB XC8 C Compiler V2.46


### PR DESCRIPTION
Since XC8 v3.10, the device family pack is required alongside the compiler. The User's Guide recommends installing it under `~/.mchp_packs`; use that location by default.

The versions I tested, from v2.40 through v3.10, all accept `-mdfp`, so pass it unconditionally.

Add a note to the README because XC8 v3.10 fails without this option.