### PR TITLE
ina3221: Cast voltage type when computing register number

### DIFF
--- a/src/ina3221.c
+++ b/src/ina3221.c
@@ -28,7 +28,7 @@ static uint8_t to_reg (uint8_t channel, enum Ina3221VoltageType type) {
          * reg 5: channel 3 shunt
          * reg 6: channel 3 bus
          */
-        return ((channel - 1) * 2) + REG_VOLTAGE_BASE + type;
+        return ((channel - 1) * 2) + REG_VOLTAGE_BASE + (uint8_t)type;
 }
 
 int8_t ina3221_data_read (struct ina3221_data *id, enum FpgaState fpga_state, enum Ina3221VoltageType type) {


### PR DESCRIPTION
Cast `type` to `uint8_t` in `to_reg()`.

This matches the intended register index arithmetic and avoids this implicit conversion warning from the compiler:

    src/ina3221.c:31:55: warning: implicit conversion loses integer
    precision: 'unsigned int' to 'uint8_t' (aka 'unsigned char') [-Wimplicit-int-conversion]
       31 |         return ((channel - 1) * 2) + REG_VOLTAGE_BASE + type;
          |         ~~~~~~ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~