### PR TITLE
usart: Use a dummy read of RCREG to clear the flags

### DIFF
--- a/src/usart.c
+++ b/src/usart.c
@@ -54,11 +54,13 @@ void putch(char ch)
         TXREG = ch;
 }
 
-void usart_start_receive (void) {
-        char buf;
+void usart_start_receive (void)
+{
         RCSTAbits.CREN = 1;
-        if (RCSTAbits.FERR || PIR1bits.RCIF)
-                buf = RCREG;
+        if (RCSTAbits.FERR || PIR1bits.RCIF) {
+                /* Read RCREG to clear the status */
+                (void)RCREG;
+        }
         rx_msg.active = 0;
         rx_msg.addr = 0;
         rx_msg.err = 0;


### PR DESCRIPTION
We do not need to store the value when the goal is only to clear the receive status. Remove `buf` and perform a dummy read of `RCREG` instead.

This avoids the compiler warning:

    src/usart.c:58:14: warning: variable 'buf' set but not
    used [-Wunused-but-set-variable]
       58 |         char buf;
          |              ^